### PR TITLE
Add simple package price calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ This repository contains utilities for calculating package prices based on selec
 
 ## Usage
 
-Run `price_calculator.py` with a list of services to get the total price:
+Run `price_calculator.py` with a list of services to see the recommended
+package and total price:
 
 ```bash
 python3 price_calculator.py design marketing
+
+# list all available services
+python3 price_calculator.py --list
 ```
 
 Available services and their default prices can be found in `price_calculator.py`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # NulizArt
+
+This repository contains utilities for calculating package prices based on selected services.
+
+## Usage
+
+Run `price_calculator.py` with a list of services to get the total price:
+
+```bash
+python3 price_calculator.py design marketing
+```
+
+Available services and their default prices can be found in `price_calculator.py`.
+

--- a/price_calculator.py
+++ b/price_calculator.py
@@ -1,0 +1,53 @@
+SERVICES = {
+    'design': 500,
+    'development': 1000,
+    'marketing': 750,
+    'support': 300,
+}
+
+
+def calculate_price(selected_services):
+    """Calculate total price for the selected services.
+
+    Parameters
+    ----------
+    selected_services : iterable of str
+        The names of services chosen by the client.
+
+    Returns
+    -------
+    int
+        The total price in dollars.
+
+    Raises
+    ------
+    KeyError
+        If any service in ``selected_services`` is not defined.
+    """
+    total = 0
+    for svc in selected_services:
+        if svc not in SERVICES:
+            raise KeyError(f"Unknown service: {svc}")
+        total += SERVICES[svc]
+    return total
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Package price calculator")
+    parser.add_argument(
+        'services',
+        nargs='+',
+        help=f"Selected services ({', '.join(SERVICES.keys())})",
+    )
+    args = parser.parse_args()
+
+    try:
+        price = calculate_price(args.services)
+        print(f"Total price: ${price}")
+    except KeyError as exc:
+        print(exc)
+        parser.print_help()
+        exit(1)
+

--- a/price_calculator.py
+++ b/price_calculator.py
@@ -1,35 +1,75 @@
+"""Simple package price calculator.
+
+Select any combination of services and the tool will recommend one of the
+predefined packages. Pricing roughly mirrors the structure used on the NulizArt
+website. For convenience, short identifiers are used for the services.
+"""
+
+# Individual service prices (used only for reference)
 SERVICES = {
-    'design': 500,
-    'development': 1000,
-    'marketing': 750,
-    'support': 300,
+    "support": 500,
+    "design": 850,
+    "marketing": 950,
+    "automation": 1200,
+    "ecommerce": 1500,
 }
+
+# Package definitions used to determine pricing based on number of services
+PACKAGES = [
+    {
+        "name": "Launch Pad",
+        "id": "launch",
+        "price": 1250,
+        "min_services": 1,
+        "max_services": 1,
+    },
+    {
+        "name": "Growth Engine",
+        "id": "growth",
+        "price": 2950,
+        "min_services": 2,
+        "max_services": 2,
+    },
+    {
+        "name": "Scale & Sustain",
+        "id": "scale",
+        "price": 5800,
+        "min_services": 3,
+        "max_services": len(SERVICES),
+    },
+]
+
+
+def recommended_package(service_count):
+    """Return the package dictionary that fits ``service_count``."""
+    for pkg in PACKAGES:
+        if pkg["min_services"] <= service_count <= pkg["max_services"]:
+            return pkg
+    # Fallback to the most expensive tier if nothing matched
+    return PACKAGES[-1]
 
 
 def calculate_price(selected_services):
-    """Calculate total price for the selected services.
+    """Calculate package price for the given services.
 
     Parameters
     ----------
-    selected_services : iterable of str
-        The names of services chosen by the client.
+    selected_services : iterable[str]
+        Identifiers for the chosen services.
 
     Returns
     -------
-    int
-        The total price in dollars.
-
-    Raises
-    ------
-    KeyError
-        If any service in ``selected_services`` is not defined.
+    tuple[str, int]
+        ``(package_name, price)``.
     """
-    total = 0
+
+    # Validate service names
     for svc in selected_services:
         if svc not in SERVICES:
             raise KeyError(f"Unknown service: {svc}")
-        total += SERVICES[svc]
-    return total
+
+    pkg = recommended_package(len(selected_services))
+    return pkg["name"], pkg["price"]
 
 
 if __name__ == "__main__":
@@ -37,15 +77,31 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Package price calculator")
     parser.add_argument(
-        'services',
-        nargs='+',
+        "services",
+        nargs="*",
         help=f"Selected services ({', '.join(SERVICES.keys())})",
     )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available services and exit",
+    )
+
     args = parser.parse_args()
 
+    if args.list:
+        print("Available services:")
+        for name in SERVICES:
+            print(f"- {name}")
+        exit(0)
+
+    if not args.services:
+        parser.print_help()
+        exit(1)
+
     try:
-        price = calculate_price(args.services)
-        print(f"Total price: ${price}")
+        package, price = calculate_price(args.services)
+        print(f"Recommended package: {package}\nTotal price: ${price}")
     except KeyError as exc:
         print(exc)
         parser.print_help()


### PR DESCRIPTION
## Summary
- implement `price_calculator.py` for calculating package pricing
- document usage in README

## Testing
- `python3 price_calculator.py design marketing`
- `python3 price_calculator.py invalid` (expected failure message)
- `python3 -m py_compile price_calculator.py`


------
https://chatgpt.com/codex/tasks/task_e_6846697001948323b3ea1c3290b7f8f7