### PR TITLE
Add invoice functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # NulizArt
+
+This repository provides a simple command line tool to estimate service costs and optionally generate an invoice.
+
+## Usage
+
+```
+python price_calculator.py SERVICE [--addons ADDON [ADDON ...]] [--invoice PATH]
+```
+
+- `SERVICE` – one of the supported services listed in the script.
+- `--addons` – optional list of add-on names.
+- `--invoice` – if provided, saves a receipt-style invoice to the given path. The extension `.txt` writes a plain text file and `.pdf` writes a PDF file.
+
+Each quote receives a unique ID. The generated invoice includes selected services, chosen add-ons, total price, the quote ID, and a booking link to schedule a free meeting.
+
+Example:
+
+```
+python price_calculator.py logo --addons source-files extra-revision --invoice myquote.pdf
+```

--- a/price_calculator.py
+++ b/price_calculator.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Simple price calculator for NulizArt services."""
+
+import argparse
+import uuid
+import os
+from typing import List
+
+# Predefined services and their prices
+SERVICES = {
+    "logo": 100.0,
+    "full-illustration": 200.0,
+    "concept-art": 150.0,
+}
+
+# Predefined add-ons and their prices
+ADDONS = {
+    "source-files": 30.0,
+    "extra-revision": 20.0,
+    "commercial-use": 50.0,
+}
+
+BOOKING_LINK = "https://example.com/free-meeting"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Calculate service price.")
+    parser.add_argument("service", choices=SERVICES.keys(), help="Service name")
+    parser.add_argument(
+        "--addons",
+        nargs="*",
+        choices=ADDONS.keys(),
+        default=[],
+        help="Optional add-ons",
+    )
+    parser.add_argument(
+        "--invoice",
+        metavar="PATH",
+        help="Save the invoice to the given path (txt or pdf)",
+    )
+    return parser.parse_args()
+
+
+def calculate_total(service: str, addons: List[str]) -> float:
+    price = SERVICES[service]
+    for addon in addons:
+        price += ADDONS[addon]
+    return price
+
+
+def build_invoice(service: str, addons: List[str], total: float, quote_id: str) -> str:
+    lines = [
+        "NulizArt Invoice",
+        f"Quote ID: {quote_id}",
+        "",
+        "Service:",
+        f" - {service}: ${SERVICES[service]:.2f}",
+    ]
+    if addons:
+        lines.append("Add-ons:")
+        for addon in addons:
+            lines.append(f" - {addon}: ${ADDONS[addon]:.2f}")
+    lines.extend([
+        "",
+        f"Total: ${total:.2f}",
+        "",
+        "Book your free meeting:",
+        BOOKING_LINK,
+    ])
+    return "\n".join(lines)
+
+
+def save_invoice(path: str, content: str) -> None:
+    if path.lower().endswith(".pdf"):
+        try:
+            from reportlab.lib.pagesizes import letter
+            from reportlab.pdfgen import canvas
+        except ImportError:
+            raise SystemExit("reportlab is required to generate PDF invoices")
+        c = canvas.Canvas(path, pagesize=letter)
+        textobject = c.beginText(50, 750)
+        for line in content.splitlines():
+            textobject.textLine(line)
+        c.drawText(textobject)
+        c.showPage()
+        c.save()
+    else:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+
+def main() -> None:
+    args = parse_args()
+    quote_id = str(uuid.uuid4())
+    total = calculate_total(args.service, args.addons)
+    invoice_text = build_invoice(args.service, args.addons, total, quote_id)
+
+    print(invoice_text)
+
+    if args.invoice:
+        save_invoice(args.invoice, invoice_text)
+        print(f"Invoice saved to {args.invoice}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple `price_calculator.py` CLI utility
- save receipt-style invoice with a unique ID to text or PDF
- document how to use the tool

## Testing
- `python price_calculator.py logo --addons source-files extra-revision --invoice example.txt`
- `python price_calculator.py logo --addons source-files extra-revision --invoice example.pdf`

------
https://chatgpt.com/codex/tasks/task_e_6846701644188323bd641582573cdcab