### PR TITLE
Create portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# NulizArt
+# Nuliz Art Portfolio
+
+A modern, responsive single-page portfolio website to showcase experience, projects, and contact information.
+
+## Getting started
+
+Open `index.html` in your browser or serve the directory with a simple static server, for example:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit <http://localhost:8000>.
+
+## Features
+
+- Responsive hero, about, skills, projects, experience, testimonials, and contact sections
+- Accessible navigation with mobile-friendly menu toggle
+- Dynamic year display and reduced-motion preference support
+- Rich visual styling with gradients, glassmorphism, and subtle animation accents

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A modern, responsive single-page portfolio website to showcase experience, proje
 
 ## Getting started
 
-Open `index.html` in your browser or serve the directory with a simple static server, for example:
+Open `index.html` in your browser or serve the directory with the helper script:
 
 ```bash
-python -m http.server 8000
+./run.sh 8000
 ```
 
-Then visit <http://localhost:8000>.
+Then visit <http://localhost:8000> (replace the port if you supply a different value).
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nuliz Art | Creative Technologist Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@300;400;500;700&family=Playfair+Display:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero" id="top">
+    <nav class="navbar" aria-label="Primary navigation">
+      <a class="logo" href="#top">Nuliz<span>Art</span></a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <ul class="nav-links">
+        <li><a href="#about">About</a></li>
+        <li><a href="#skills">Skills</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#experience">Experience</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+    <div class="hero-content">
+      <div class="hero-text">
+        <p class="eyebrow">Creative Technologist & Front-End Developer</p>
+        <h1>Hi, I'm <span>Nuliz Art</span>.</h1>
+        <p class="tagline">I blend design sensibilities with modern web engineering to craft immersive digital experiences that feel intuitive, inclusive, and delightful.</p>
+        <div class="hero-actions">
+          <a class="btn primary" href="#projects">View Projects</a>
+          <a class="btn secondary" href="#contact">Let's Collaborate</a>
+        </div>
+        <ul class="social-links" aria-label="Social links">
+          <li><a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a></li>
+          <li><a href="https://github.com" target="_blank" rel="noreferrer">GitHub</a></li>
+          <li><a href="mailto:hello@nulizart.com">Email</a></li>
+        </ul>
+      </div>
+      <div class="hero-visual" aria-hidden="true">
+        <div class="orb orb-one"></div>
+        <div class="orb orb-two"></div>
+        <div class="portrait-frame">
+          <div class="portrait"></div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="about" class="section about">
+      <div class="section-header">
+        <p class="eyebrow">About</p>
+        <h2>Design-driven engineering with a human touch</h2>
+      </div>
+      <div class="section-content">
+        <p>
+          Over the past five years I've built products for SaaS startups, digital agencies, and mission-driven organizations.
+          I love translating complex ideas into elegant interactions, and partnering with multi-disciplinary teams to deliver fast, accessible web applications.
+        </p>
+        <p>
+          When I'm not pushing pixels or optimizing performance budgets, you can find me sketching concepts, exploring new creative coding tools, or mentoring early-career developers.
+        </p>
+        <div class="stats">
+          <div>
+            <span class="stat-number">5+</span>
+            <span class="stat-label">Years of experience</span>
+          </div>
+          <div>
+            <span class="stat-number">30+</span>
+            <span class="stat-label">Projects delivered</span>
+          </div>
+          <div>
+            <span class="stat-number">12</span>
+            <span class="stat-label">Happy partners</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="skills" class="section skills">
+      <div class="section-header">
+        <p class="eyebrow">Skills</p>
+        <h2>Crafting thoughtful experiences from concept to code</h2>
+      </div>
+      <div class="skills-grid">
+        <article class="skill-card">
+          <h3>Design Systems</h3>
+          <p>Atomic design, component libraries, accessibility audits, Figma prototyping, and brand storytelling.</p>
+        </article>
+        <article class="skill-card">
+          <h3>Front-End Engineering</h3>
+          <p>Semantic HTML, CSS architecture, TypeScript, React, Next.js, animations, and performance optimization.</p>
+        </article>
+        <article class="skill-card">
+          <h3>Creative Technology</h3>
+          <p>Generative art, WebGL, data visualization, immersive storytelling, and interactive installations.</p>
+        </article>
+        <article class="skill-card">
+          <h3>Collaboration</h3>
+          <p>Cross-functional leadership, agile delivery, stakeholder facilitation, and inclusive team culture.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="projects" class="section projects">
+      <div class="section-header">
+        <p class="eyebrow">Projects</p>
+        <h2>Selected work</h2>
+      </div>
+      <div class="projects-grid">
+        <article class="project-card">
+          <div class="project-image project-one"></div>
+          <div class="project-content">
+            <h3>Neon Atlas</h3>
+            <p>An immersive data storytelling platform for urban planners. Built with Next.js, D3, and Mapbox to reveal patterns in mobility data.</p>
+            <div class="project-meta">
+              <span>Next.js</span>
+              <span>D3.js</span>
+              <span>Mapbox</span>
+            </div>
+            <a class="project-link" href="#">View case study</a>
+          </div>
+        </article>
+
+        <article class="project-card">
+          <div class="project-image project-two"></div>
+          <div class="project-content">
+            <h3>Flux Studio</h3>
+            <p>A collaborative design system for a health-tech startup, featuring custom UI components and accessibility baked into every interaction.</p>
+            <div class="project-meta">
+              <span>Design System</span>
+              <span>TypeScript</span>
+              <span>Storybook</span>
+            </div>
+            <a class="project-link" href="#">Explore project</a>
+          </div>
+        </article>
+
+        <article class="project-card">
+          <div class="project-image project-three"></div>
+          <div class="project-content">
+            <h3>Echo Exhibit</h3>
+            <p>An interactive installation blending generative visuals with live audio input. Showcased at the Digital Futures festival.</p>
+            <div class="project-meta">
+              <span>Three.js</span>
+              <span>Web Audio API</span>
+              <span>Creative Coding</span>
+            </div>
+            <a class="project-link" href="#">See installation</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="experience" class="section experience">
+      <div class="section-header">
+        <p class="eyebrow">Experience</p>
+        <h2>Where I've made an impact</h2>
+      </div>
+      <div class="timeline">
+        <article class="timeline-item">
+          <span class="timeline-year">2022 – Present</span>
+          <div class="timeline-content">
+            <h3>Lead Front-End Engineer · Aurora Labs</h3>
+            <p>Guided a distributed team to rebuild the company platform with a component-driven architecture, reducing design-debt by 45%.</p>
+          </div>
+        </article>
+        <article class="timeline-item">
+          <span class="timeline-year">2019 – 2022</span>
+          <div class="timeline-content">
+            <h3>Senior Product Designer · Canvas Collective</h3>
+            <p>Shipped research-backed experiences for fintech and edtech clients, delivering measurable improvements in adoption and retention.</p>
+          </div>
+        </article>
+        <article class="timeline-item">
+          <span class="timeline-year">2017 – 2019</span>
+          <div class="timeline-content">
+            <h3>Creative Developer · Studio Meridian</h3>
+            <p>Implemented interactive narratives and immersive microsites for global brands, earning multiple industry awards.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="testimonials" class="section testimonials">
+      <div class="section-header">
+        <p class="eyebrow">Testimonials</p>
+        <h2>Trusted collaborators share their stories</h2>
+      </div>
+      <div class="testimonials-grid">
+        <blockquote>
+          <p>“Nuliz consistently turns visionary ideas into polished experiences. Their leadership kept our launch on track and energized the team.”</p>
+          <cite>— Jordan Lee, Product Director at Aurora Labs</cite>
+        </blockquote>
+        <blockquote>
+          <p>“From research through implementation, they deliver inclusive solutions that delight users and stakeholders alike.”</p>
+          <cite>— Priya Patel, Head of Design at Canvas Collective</cite>
+        </blockquote>
+        <blockquote>
+          <p>“A rare blend of strategic thinking and hands-on craft. Our interactive exhibit drew record engagement thanks to their ingenuity.”</p>
+          <cite>— Malik Osei, Curator at Digital Futures</cite>
+        </blockquote>
+      </div>
+    </section>
+
+    <section id="contact" class="section contact">
+      <div class="contact-card">
+        <div class="section-header">
+          <p class="eyebrow">Contact</p>
+          <h2>Let's build something remarkable</h2>
+        </div>
+        <p class="contact-text">Share a few details about your project or opportunity and I'll follow up within two business days.</p>
+        <form class="contact-form">
+          <div class="form-group">
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" placeholder="Your name" required />
+          </div>
+          <div class="form-group">
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" placeholder="name@example.com" required />
+          </div>
+          <div class="form-group">
+            <label for="message">Project details</label>
+            <textarea id="message" name="message" rows="4" placeholder="Share a quick overview"></textarea>
+          </div>
+          <button type="submit" class="btn primary">Send message</button>
+        </form>
+        <p class="contact-footer">Prefer email? Reach out directly at <a href="mailto:hello@nulizart.com">hello@nulizart.com</a></p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>© <span id="year"></span> Nuliz Art. Crafted with intention.</p>
+    <a class="back-to-top" href="#top">Back to top</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=${1:-8000}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to run the static server" >&2
+  exit 1
+fi
+
+python3 -m http.server "$PORT"

--- a/script.js
+++ b/script.js
@@ -1,0 +1,28 @@
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+const yearEl = document.getElementById('year');
+
+yearEl.textContent = new Date().getFullYear();
+
+if (navToggle && navLinks) {
+  const toggleNav = () => {
+    const isOpen = navLinks.classList.toggle('open');
+    navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  };
+
+  navToggle.addEventListener('click', toggleNav);
+  navLinks.addEventListener('click', event => {
+    if (event.target.tagName === 'A' && navLinks.classList.contains('open')) {
+      toggleNav();
+    }
+  });
+}
+
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+if (prefersReducedMotion.matches) {
+  document.documentElement.style.setProperty('--transition-speed', '0s');
+  document.querySelectorAll('.orb').forEach(orb => {
+    orb.style.animation = 'none';
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,643 @@
+:root {
+  --bg: #0d0c1d;
+  --bg-alt: #15142b;
+  --surface: #1d1b3c;
+  --primary: #7f5af0;
+  --primary-soft: rgba(127, 90, 240, 0.2);
+  --accent: #f25f4c;
+  --text: #f9f7ff;
+  --text-muted: rgba(249, 247, 255, 0.68);
+  --eyebrow: #ffeea8;
+  --border: rgba(255, 255, 255, 0.12);
+  --shadow: rgba(0, 0, 0, 0.35);
+  --max-width: 1120px;
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  scroll-behavior: smooth;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Fira Sans', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top, rgba(127, 90, 240, 0.18), transparent 55%), var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.hero {
+  padding: 48px 24px 120px;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 10% 20% -40% 20%;
+  background: radial-gradient(circle, rgba(242, 95, 76, 0.18), transparent 65%);
+  filter: blur(40px);
+  z-index: -2;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max-width);
+  margin: 0 auto 48px;
+  padding: 12px 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(21, 20, 43, 0.75);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 24px;
+  z-index: 10;
+}
+
+.logo {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.5rem;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.logo span {
+  color: var(--accent);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  width: 44px;
+  height: 44px;
+  padding: 10px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: rgba(13, 12, 29, 0.65);
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.nav-toggle span {
+  display: block;
+  height: 2px;
+  background: var(--text);
+  border-radius: 999px;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 28px;
+  margin: 0;
+  padding: 0;
+  font-weight: 500;
+}
+
+.nav-links a {
+  color: var(--text-muted);
+  transition: color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  color: var(--text);
+}
+
+.hero-content {
+  display: grid;
+  gap: 48px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: center;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.8rem, 4vw + 1rem, 4.5rem);
+  line-height: 1.1;
+  margin: 12px 0 24px;
+  font-family: 'Playfair Display', serif;
+}
+
+.hero-text h1 span {
+  color: var(--primary);
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--eyebrow);
+  font-weight: 600;
+}
+
+.tagline {
+  max-width: 540px;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 28px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.98rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--primary), #6246ea);
+  box-shadow: 0 16px 32px rgba(127, 90, 240, 0.25);
+}
+
+.btn.primary:hover {
+  transform: translateY(-2px);
+}
+
+.btn.secondary {
+  background: rgba(21, 20, 43, 0.7);
+  border-color: var(--border);
+}
+
+.social-links {
+  display: flex;
+  gap: 20px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.hero-visual {
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: 48px 0;
+}
+
+.orb {
+  position: absolute;
+  width: clamp(220px, 30vw, 320px);
+  height: clamp(220px, 30vw, 320px);
+  border-radius: 50%;
+  filter: blur(0);
+  opacity: 0.8;
+  z-index: -2;
+}
+
+.orb-one {
+  background: radial-gradient(circle at 30% 30%, rgba(127, 90, 240, 0.65), transparent 70%);
+  animation: float 12s ease-in-out infinite;
+}
+
+.orb-two {
+  background: radial-gradient(circle at 70% 70%, rgba(242, 95, 76, 0.45), transparent 70%);
+  animation: float 16s ease-in-out infinite reverse;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(12px, -18px, 0) scale(1.05);
+  }
+}
+
+.portrait-frame {
+  width: clamp(260px, 40vw, 360px);
+  height: clamp(320px, 48vw, 440px);
+  background: linear-gradient(180deg, rgba(127, 90, 240, 0.4), rgba(13, 12, 29, 0.9));
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  position: relative;
+  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.45);
+}
+
+.portrait-frame::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: calc(var(--radius-lg) - 12px);
+}
+
+.portrait {
+  width: 100%;
+  height: 100%;
+  border-radius: calc(var(--radius-lg) - 20px);
+  background: linear-gradient(160deg, rgba(249, 247, 255, 0.12), rgba(13, 12, 29, 0.95)), url('https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=800&q=80') center/cover;
+  filter: saturate(1.1);
+}
+
+.section {
+  padding: 120px 24px;
+}
+
+.section-header {
+  max-width: 720px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.section h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.1rem, 2vw + 1.2rem, 3rem);
+  margin: 16px 0 0;
+}
+
+.section-content,
+.skills-grid,
+.projects-grid,
+.timeline,
+.testimonials-grid {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.section-content p {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.stat-number {
+  display: block;
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.stat-label {
+  color: var(--text-muted);
+}
+
+.skills-grid {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.skill-card {
+  padding: 28px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(160deg, rgba(21, 20, 43, 0.92), rgba(21, 20, 43, 0.6));
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.22);
+}
+
+.skill-card h3 {
+  margin-top: 0;
+  font-size: 1.2rem;
+  margin-bottom: 12px;
+}
+
+.skill-card p {
+  color: var(--text-muted);
+}
+
+.projects-grid {
+  display: grid;
+  gap: 32px;
+}
+
+.project-card {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: rgba(21, 20, 43, 0.85);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.28);
+}
+
+.project-image {
+  min-height: 240px;
+  background-size: cover;
+  background-position: center;
+}
+
+.project-one {
+  background-image: linear-gradient(120deg, rgba(15, 9, 48, 0.6), rgba(0, 0, 0, 0.65)), url('https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=1100&q=80');
+}
+
+.project-two {
+  background-image: linear-gradient(120deg, rgba(16, 8, 54, 0.6), rgba(0, 0, 0, 0.65)), url('https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&w=1100&q=80');
+}
+
+.project-three {
+  background-image: linear-gradient(120deg, rgba(17, 7, 45, 0.6), rgba(0, 0, 0, 0.65)), url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1100&q=80');
+}
+
+.project-content {
+  padding: 32px;
+}
+
+.project-content h3 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.project-content p {
+  color: var(--text-muted);
+  margin-bottom: 24px;
+}
+
+.project-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.project-meta span {
+  background: rgba(127, 90, 240, 0.15);
+  color: var(--primary);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.project-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.timeline {
+  display: grid;
+  gap: 24px;
+  position: relative;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 16px;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(127, 90, 240, 0.6), rgba(242, 95, 76, 0.3));
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 32px;
+  padding-left: 48px;
+}
+
+.timeline-year {
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.timeline-content {
+  background: rgba(21, 20, 43, 0.7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 24px 28px;
+  box-shadow: 0 20px 32px rgba(0, 0, 0, 0.22);
+}
+
+.testimonials {
+  background: var(--bg-alt);
+}
+
+.testimonials-grid {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+blockquote {
+  margin: 0;
+  padding: 28px;
+  border-radius: var(--radius-md);
+  background: rgba(21, 20, 43, 0.7);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-style: italic;
+  position: relative;
+}
+
+blockquote::before {
+  content: '“';
+  position: absolute;
+  top: -20px;
+  left: 16px;
+  font-size: 4rem;
+  color: rgba(127, 90, 240, 0.2);
+}
+
+cite {
+  display: block;
+  margin-top: 20px;
+  color: var(--text);
+  font-style: normal;
+  font-weight: 600;
+}
+
+.contact {
+  background: linear-gradient(135deg, rgba(127, 90, 240, 0.2), rgba(21, 20, 43, 0.95));
+}
+
+.contact-card {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 48px;
+  border-radius: var(--radius-lg);
+  background: rgba(13, 12, 29, 0.85);
+  border: 1px solid var(--border);
+  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.35);
+}
+
+.contact-text {
+  color: var(--text-muted);
+  margin-bottom: 24px;
+}
+
+.contact-form {
+  display: grid;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.form-group {
+  display: grid;
+  gap: 8px;
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+textarea {
+  padding: 14px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 14, 35, 0.9);
+  color: var(--text);
+  font: inherit;
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.contact-footer {
+  color: var(--text-muted);
+}
+
+.contact-footer a {
+  color: var(--accent);
+}
+
+.footer {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-muted);
+  background: rgba(13, 12, 29, 0.85);
+}
+
+.back-to-top {
+  display: inline-flex;
+  margin-top: 12px;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .hero-content {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-text,
+  .hero-actions,
+  .social-links {
+    justify-content: center;
+  }
+
+  .navbar {
+    position: static;
+  }
+
+  .timeline::before {
+    left: 8px;
+  }
+
+  .timeline-item {
+    grid-template-columns: 1fr;
+    padding-left: 24px;
+  }
+}
+
+@media (max-width: 720px) {
+  .nav-toggle {
+    display: flex;
+  }
+
+  .nav-links {
+    position: absolute;
+    top: 72px;
+    right: 24px;
+    flex-direction: column;
+    gap: 16px;
+    background: rgba(13, 12, 29, 0.92);
+    border-radius: var(--radius-md);
+    padding: 20px 24px;
+    border: 1px solid var(--border);
+    box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-10px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .nav-links.open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .navbar {
+    padding: 12px 16px;
+  }
+
+  .contact-card {
+    padding: 32px;
+  }
+}
+
+@media (max-width: 540px) {
+  .hero {
+    padding-bottom: 80px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .section {
+    padding: 80px 20px;
+  }
+
+  .project-card {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-card {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive single-page portfolio with sections for skills, projects, experience, testimonials, and contact
- style the site with modern gradients, glassmorphism effects, and adaptive layouts
- enhance interactivity with a mobile navigation toggle, dynamic year display, and updated README instructions

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68fed5a9a3708323b47da62da9bcb47f